### PR TITLE
Inference Fix: Zero BOS

### DIFF
--- a/nemo/collections/tts/data/speechllm/t5_speechllm_dataset.py
+++ b/nemo/collections/tts/data/speechllm/t5_speechllm_dataset.py
@@ -431,9 +431,10 @@ class T5SpeechLMDataset(BasePromptLearningDataset):
                 if total_context_len > 600
                 else int(total_context_len * random.uniform(0.2, 0.5)),
             )
-            start_token_index = random.randint(
-                0, total_context_len - reduced_len
-            )  # start index can be greater than 440
+            # start_token_index = random.randint(
+            #     0, total_context_len - reduced_len
+            # )  # start index can be greater than 440
+            start_token_index = 0
             context_tokens[0] = context_tokens[0][
                 :, start_token_index : min(start_token_index + 440, start_token_index + reduced_len)
             ]
@@ -861,7 +862,8 @@ class T5SpeechLMDataset(BasePromptLearningDataset):
             assert self.context_duration_min == self.context_duration_max, "CONTEXTANSWER only supports fixed context duration"
             reference_codec_len = int(self.context_duration_min * self.codebook_fps)
             assert context_tokens.shape[1] >= reference_codec_len, "CONTEXTANSWER context duration is less than min duration {} {} {}".format(context_tokens.shape[1], reference_codec_len, context_codec_path)
-            si = rng.randint(0, context_tokens.shape[1] - reference_codec_len)
+            # si = rng.randint(0, context_tokens.shape[1] - reference_codec_len)
+            si = 0
             context_tokens = context_tokens[:, si:si+reference_codec_len]
             answer_tokens[0] = (answer_tokens[0] + self.speech_offset).long()
             pad_tokens = torch.zeros(self.num_speech_codebooks, 1).long()

--- a/nemo/collections/tts/data/speechllm/t5_speechllm_dataset.py
+++ b/nemo/collections/tts/data/speechllm/t5_speechllm_dataset.py
@@ -431,10 +431,9 @@ class T5SpeechLMDataset(BasePromptLearningDataset):
                 if total_context_len > 600
                 else int(total_context_len * random.uniform(0.2, 0.5)),
             )
-            # start_token_index = random.randint(
-            #     0, total_context_len - reduced_len
-            # )  # start index can be greater than 440
-            start_token_index = 0
+            start_token_index = random.randint(
+                0, total_context_len - reduced_len
+            )  # start index can be greater than 440
             context_tokens[0] = context_tokens[0][
                 :, start_token_index : min(start_token_index + 440, start_token_index + reduced_len)
             ]
@@ -862,8 +861,7 @@ class T5SpeechLMDataset(BasePromptLearningDataset):
             assert self.context_duration_min == self.context_duration_max, "CONTEXTANSWER only supports fixed context duration"
             reference_codec_len = int(self.context_duration_min * self.codebook_fps)
             assert context_tokens.shape[1] >= reference_codec_len, "CONTEXTANSWER context duration is less than min duration {} {} {}".format(context_tokens.shape[1], reference_codec_len, context_codec_path)
-            # si = rng.randint(0, context_tokens.shape[1] - reference_codec_len)
-            si = 0
+            si = rng.randint(0, context_tokens.shape[1] - reference_codec_len)
             context_tokens = context_tokens[:, si:si+reference_codec_len]
             answer_tokens[0] = (answer_tokens[0] + self.speech_offset).long()
             pad_tokens = torch.zeros(self.num_speech_codebooks, 1).long()

--- a/nemo/collections/tts/models/speechllm/megatron_t5_speechllm_model.py
+++ b/nemo/collections/tts/models/speechllm/megatron_t5_speechllm_model.py
@@ -1416,14 +1416,15 @@ class MegatronT5SpeechLMModel(MegatronBaseSpeechLM):
             end_inference_loop_at = None
             fwd_bwd_function = get_forward_backward_func()
             encoder_output = None
-            for t in range(self.decoder_context_len, dec_input.shape[2] - 1):
+            for t in range(self.decoder_context_len + 1, dec_input.shape[2] - 1):
+                # import ipdb; ipdb.set_trace()
                 # Start at 0 if encoder context, else context_len
                 if t % 100 == 0:
                     logging.info("Timestep {}".format(t))
                 if t == end_inference_loop_at:
                     print("All ends detected")
                     break
-                if t == self.decoder_context_len:
+                if t == self.decoder_context_len + 1:
                     # Run first step manually
                     # logging.debug(f"Calling first step with input size:{dec_input[:, :, : t + 1].shape} and mask:{dec_input_mask[:, : t + 1].shape}")
                     output_logits, _, token_and_speech_logits = self.forward(
@@ -1601,7 +1602,7 @@ class MegatronT5SpeechLMModel(MegatronBaseSpeechLM):
             for i in range(batch_size):
                 audio_len = (labels[i][0] != 0).sum().item()
                 # step = batch_idx * self.test_dataloader().batch_size + i
-                step = batch_idx * test_dataloader_batch_size + i 
+                step = batch_idx * test_dataloader_batch_size + i
                 if torch.count_nonzero(speech_mask) > 0:
                     dec_input_to_1024 = self.convert_tokens_to_range(dec_input_raw[i, :, 0:audio_len])
                     dec_input_to_1024_answer = dec_input_to_1024[:,self.decoder_context_len+1:]

--- a/nemo/collections/tts/models/speechllm/megatron_t5_speechllm_model.py
+++ b/nemo/collections/tts/models/speechllm/megatron_t5_speechllm_model.py
@@ -1417,7 +1417,6 @@ class MegatronT5SpeechLMModel(MegatronBaseSpeechLM):
             fwd_bwd_function = get_forward_backward_func()
             encoder_output = None
             for t in range(self.decoder_context_len + 1, dec_input.shape[2] - 1):
-                # import ipdb; ipdb.set_trace()
                 # Start at 0 if encoder context, else context_len
                 if t % 100 == 0:
                     logging.info("Timestep {}".format(t))


### PR DESCRIPTION
If using 2.9s context, We currently use 1 BOS code, 248 codes for the context, and 1 all-zero frame. The current inference did not include this all-zero frame, and this PR fixes that.