### PR TITLE
Fix error in inferencing with a text context

### DIFF
--- a/nemo/collections/tts/models/speechllm/megatron_t5_speechllm_model.py
+++ b/nemo/collections/tts/models/speechllm/megatron_t5_speechllm_model.py
@@ -1999,6 +1999,12 @@ class MegatronT5SpeechLMModel(MegatronBaseSpeechLM):
 
                         spk_embedding_context_wavlm = wavlm_embeddings[0].cpu().detach().numpy().flatten()
 
+                        # SQUIM MOS prediction versus the audio context. SQUIM MOS allows a non-matching reference.
+                        squim_mos_score_context_gt = squim_mos_model(torch.from_numpy(gt_16khz_wav).to(device).unsqueeze(0), context_wav.to(device).unsqueeze(0)).item()
+                        squim_mos_score_context_pred = squim_mos_model(torch.from_numpy(pred_16khz_wav).to(device).unsqueeze(0), context_wav.to(device).unsqueeze(0)).item()
+                        squim_mos_list_context_gt.append(squim_mos_score_context_gt)
+                        squim_mos_list_context_pred.append(squim_mos_score_context_pred)
+
                     pred_similarity_context = np.dot(spk_embedding_context, spk_embedding_pred) / (
                         np.linalg.norm(spk_embedding_context) * np.linalg.norm(spk_embedding_pred)
                     )
@@ -2013,10 +2019,6 @@ class MegatronT5SpeechLMModel(MegatronBaseSpeechLM):
                         np.linalg.norm(spk_embedding_context_wavlm) * np.linalg.norm(spk_embedding_gt_wavlm)
                     )
 
-                    squim_mos_score_context_gt = squim_mos_model(torch.from_numpy(gt_16khz_wav).to(device).unsqueeze(0), context_wav.to(device).unsqueeze(0)).item()
-                    squim_mos_score_context_pred = squim_mos_model(torch.from_numpy(pred_16khz_wav).to(device).unsqueeze(0), context_wav.to(device).unsqueeze(0)).item()
-                    squim_mos_list_context_gt.append(squim_mos_score_context_gt)
-                    squim_mos_list_context_pred.append(squim_mos_score_context_pred)
 
                     if log_scalars:
                         self.logger.experiment.add_scalar(f'Inf SV Cossim Context Pred', pred_similarity_context, step)


### PR DESCRIPTION
When using text context there was an error in `predict_step()` due to a portion of the inference code relying on the availability of an audio context. This fix makes that code only run when audio context is provided. Also: added a comment.

**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation
