### PR TITLE
Handle deprecation of matplotlib function

### DIFF
--- a/nemo/collections/tts/parts/utils/helpers.py
+++ b/nemo/collections/tts/parts/utils/helpers.py
@@ -632,8 +632,14 @@ def plot_gate_outputs_to_numpy(gate_targets, gate_outputs):
 
 
 def save_figure_to_numpy(fig):
-    img_array = np.array(fig.canvas.renderer.buffer_rgba())
-    return img_array
+    # save it to a numpy array.
+    # note: canvas.draw() must be called before this to populate the buffer
+    buffer = fig.canvas.buffer_rgba()
+    width, height = fig.canvas.get_width_height()
+    data = np.frombuffer(buffer, dtype=np.uint8).reshape(height, width, 4)
+    # drop the alpha channel
+    data = data[:,:,:-1]
+    return data
 
 
 @rank_zero_only


### PR DESCRIPTION
A recent change to Matplotlib deprecated the function `fig.canvas.tostring_rgb()`. I had fixed that on my branch; meanwhile looks like there was also a fix/workaround implemented on the magpietts_2503 branch but that workaround doesn't reshape the array to `(height, weight, 3)` (where 3 is for RGB), which is the shape that used to be returned and that calling functions probably expect. This PR adds adds that step.

For reference, here's a diff versus the earlier code:
`https://github.com/rfejgin/NeMo/commit/13fafdf12854fe314f18d46525dc6b230a1d0051`