### PR TITLE
[magpietts] added WandbLogger support and restructure TensorBoardLogger.

### DIFF
--- a/examples/tts/conf/magpietts/magpietts_en.yaml
+++ b/examples/tts/conf/magpietts/magpietts_en.yaml
@@ -186,6 +186,7 @@ exp_manager:
   wandb_logger_kwargs:
     name: null
     project: null
+    resume: true
   create_checkpoint_callback: true
   checkpoint_callback_params:
     monitor: val_loss


### PR DESCRIPTION
Tested and confirmed either logger worked well.

**Main Changes:**
* structured both loggers for train/val/test.
* enable `resume` param to ensure the resumed training logs being merged on the previous run id.
* removed `tb_logger` func.

**Guidance TensorBoardLogger**
```bash
exp_manager.resume_if_exists=true \
exp_manager.exp_dir=/exp_dir \
+exp_manager.version=0 \
++exp_manager.name="magpieTTS" \
++exp_manager.create_tensorboard_logger=true \
++exp_manager.create_wandb_logger=false \
```

Guidance WandbLogger
```bash
exp_manager.resume_if_exists=true \
exp_manager.exp_dir=/exp_dir \
++exp_manager.name="magpieTTS" \
++exp_manager.create_tensorboard_logger=False \
++exp_manager.create_wandb_logger=true \
++exp_manager.wandb_logger_kwargs.entity=aiapps \
++exp_manager.wandb_logger_kwargs.project=${PROJECT} \
++exp_manager.wandb_logger_kwargs.group=${CODECMODEL_NAME} \
++exp_manager.wandb_logger_kwargs.name=${EXP_NAME} \
++exp_manager.wandb_logger_kwargs.resume=true \
```
