### PR TITLE
[bugfix] ensure cloning codes tensor before replacing bos and eos with the padding audio token.

### DIFF
--- a/nemo/collections/tts/models/magpietts.py
+++ b/nemo/collections/tts/models/magpietts.py
@@ -307,11 +307,17 @@ class MagpieTTSModel(ModelPT):
         # codes_len: (B,)
         self._codec_model.eval()
         with torch.no_grad():
-            # Replace eos and bos tokens with padding in codes tensor
-            codes[codes == self.audio_bos_id] = 0  # zero is the padding token in the audio codebook
-            codes[codes == self.audio_eos_id] = 0
-            # self.additional_models['codec'] = self.additional_models['codec'].to(codes.device)
-            audio, audio_len = self._codec_model.decode(tokens=codes, tokens_len=codes_len)
+            # Make a copy to avoid modifying the original tensor if it's used elsewhere
+            codes_copy = codes.clone()
+            # Replace eos and bos tokens with padding in the copied tensor
+            codes_copy[codes == self.audio_bos_id] = 0  # zero is the padding token
+            codes_copy[codes == self.audio_eos_id] = 0
+
+            # Force fp32 for the internal operations of the codec decoding
+            with torch.autocast(device_type=codes.device.type, enabled=False):
+                # Pass the modified integer token IDs
+                audio, audio_len = self._codec_model.decode(tokens=codes_copy, tokens_len=codes_len)
+
             # audio: (B, T)
             # audio_len: (B,)
             return audio, audio_len


### PR DESCRIPTION
1. call `.clone()` to avoid in-place modification since other places may reuse the input `codes` tensor.
2. disable `autocast` to `bf16` during codec to audio reconstruction. Verified that the reconstructed audio sounds much better when keeping fp32. For example, with the wrapper, `pred_audio.dtype` keeps 

*original info before applying this change*
```python
    510         self,
    511         logits,
    512         target_audio_codes,
    513         audio_codes_lens_target,
    514         context_audio_codes=None,
    515         context_audio_codes_lens=None,
    516     ):
    517         pred_audio_codes = self.logits_to_audio_codes(logits, audio_codes_lens_target)
    518         pred_audio, pred_audio_lens = self.codes_to_audio(pred_audio_codes, audio_codes_lens_target)
    519         target_audio, target_audio_lens = self.codes_to_audio(target_audio_codes, audio_codes_lens_target)
--> 520         import ipdb; ipdb.set_trace()

ipdb> x = self.logits_to_audio_codes(logits, audio_codes_lens_target)
ipdb> torch.equal(x[0], pred_audio_codes[0])
False
ipdb> audio_codes_lens_target[0]
tensor(82, device='cuda:0', dtype=torch.int32)
ipdb> x[0][:,81]
tensor([2047, 2047, 2047, 2047, 2047, 2047, 2047, 2047], device='cuda:0')
ipdb> pred_audio_codes[0][:,81]
tensor([0, 0, 0, 0, 0, 0, 0, 0], device='cuda:0')
ipdb> pred_audio_codes.dtype
torch.int64
ipdb> x.dtype
torch.int64
ipdb> pred_audio.dtype
torch.bfloat16
```
*info after applying this change*
```python
    520         context_audio_codes_lens=None,
    521     ):
    522         pred_audio_codes = self.logits_to_audio_codes(logits, audio_codes_lens_target)
    523         pred_audio, pred_audio_lens = self.codes_to_audio(pred_audio_codes, audio_codes_lens_target)
    524         target_audio, target_audio_lens = self.codes_to_audio(target_audio_codes, audio_codes_lens_target)
    525         import ipdb; ipdb.set_trace()
--> 526         context_audio, context_audio_lens = None, None
    527         if context_audio_codes is not None and context_audio_codes.shape[2] > 3:
    528             # > 3 ensures, it is a valid context audio tensor (and not dummy tensor used in text context)
    529             context_audio, context_audio_lens = self.codes_to_audio(context_audio_codes, context_audio_codes_lens)
    530

ipdb> pred_audio.dtype
torch.float32
ipdb> pred_audio_codes[0][:81]
tensor([2047, 2047, 2047, 2047, 2047, 2047, 2047, 2047], device='cuda:0')
```
