### PR TITLE
Bug fix in context text embedding initialization

### DIFF
--- a/nemo/collections/tts/models/magpietts.py
+++ b/nemo/collections/tts/models/magpietts.py
@@ -124,9 +124,6 @@ class MagpieTTSModel(ModelPT):
         self.context_audio_bos_id = cfg.num_audio_tokens_per_codebook - 2  # For backward compatibility
         self.context_audio_eos_id = cfg.num_audio_tokens_per_codebook - 1  # For backward compatibility
 
-        if self.use_text_conditioning_encoder:
-            self.context_text_embedding = nn.Embedding(self.text_conditioning_tokenizer.vocab_size, cfg.embedding_dim)
-
         self.model_type = cfg.get('model_type', 'single_encoder_sv_tts')
 
         if self.model_type == 'decoder_context_tts':
@@ -139,6 +136,9 @@ class MagpieTTSModel(ModelPT):
         self.use_kv_cache_for_inference = cfg.get('use_kv_cache_for_inference', False)
 
         super().__init__(cfg=cfg, trainer=trainer)
+
+        if self.use_text_conditioning_encoder:
+            self.context_text_embedding = nn.Embedding(self.text_conditioning_tokenizer.vocab_size, cfg.embedding_dim)
 
         audio_embeddings = []
         for _ in range(cfg.num_audio_codebooks):

--- a/scripts/magpietts/infer_and_evaluate.py
+++ b/scripts/magpietts/infer_and_evaluate.py
@@ -82,7 +82,7 @@ def run_inference(
         with open_dict(model_cfg):
             model_cfg = update_config(model_cfg, codecmodel_path)
 
-        model = MagpieTTS_Model(cfg=model_cfg)
+        model = MagpieTTSModel(cfg=model_cfg)
         model.use_kv_cache_for_inference = True
 
         # Load weights from checkpoint file
@@ -91,10 +91,10 @@ def run_inference(
         model.load_state_dict(ckpt['state_dict'])
         checkpoint_name = checkpoint_file.split("/")[-1].split(".ckpt")[0]
     elif nemo_file is not None:
-        model_cfg = MagpieTTS_Model.restore_from(nemo_file, return_config=True)
+        model_cfg = MagpieTTSModel.restore_from(nemo_file, return_config=True)
         with open_dict(model_cfg):
             model_cfg = update_config(model_cfg, codecmodel_path)
-        model = MagpieTTS_Model.restore_from(nemo_file, override_config_path=model_cfg)
+        model = MagpieTTSModel.restore_from(nemo_file, override_config_path=model_cfg)
         model.use_kv_cache_for_inference = True
         checkpoint_name = nemo_file.split("/")[-1].split(".nemo")[0]
     else:
@@ -164,7 +164,9 @@ def run_inference(
                 context_duration_max=context_durration_max,
             )
             assert len(test_dataset) == len(manifest_records), "Dataset length and manifest length should be the same. Dataset length: {}, Manifest length: {}".format(len(test_dataset), len(manifest_records))
-            test_dataset.text_tokenizer, test_dataset.text_conditioning_tokenizer = model._setup_tokenizers(model.cfg, mode='test')
+            
+            test_dataset.text_tokenizer = model.tokenizer
+            test_dataset.text_conditioning_tokenizer = model.text_conditioning_tokenizer
 
             test_data_loader = torch.utils.data.DataLoader(
                 test_dataset,


### PR DESCRIPTION
Context text embedding should be initialized after super().__init__(cfg=cfg, trainer=trainer), otherwise it throws an exception.