### PR TITLE
Bugfix: num_audio_tokens_per_codebook

### DIFF
--- a/examples/tts/conf/magpietts/magpietts_dc_en.yaml
+++ b/examples/tts/conf/magpietts/magpietts_dc_en.yaml
@@ -21,7 +21,7 @@ model:
   context_duration_min: 3.0
   context_duration_max: 5.0
   num_audio_codebooks: 8
-  num_audio_tokens_per_codebook: 2018 # 2016 from codec + Keep at least 2 extra for eos/bos ids
+  num_audio_tokens_per_codebook: 2024 # 2016 from codec + 8 reserved tokens (for things like EOS/BOS etc.)
   codec_model_downsample_factor: 1024
   load_cached_codes_if_available: true
   prior_scaling_factor: 0.5

--- a/examples/tts/conf/magpietts/magpietts_en.yaml
+++ b/examples/tts/conf/magpietts/magpietts_en.yaml
@@ -23,7 +23,7 @@ model:
   context_duration_min: 3.0
   context_duration_max: 5.0
   num_audio_codebooks: 8
-  num_audio_tokens_per_codebook: 2018 # 2016 from codec + Keep at least 2 extra for eos/bos ids
+  num_audio_tokens_per_codebook: 2024 # 2016 from codec + 8 reserved tokens (for things like EOS/BOS etc.)
   codec_model_downsample_factor: 1024
   load_cached_codes_if_available: true
   prior_scaling_factor: 0.5

--- a/examples/tts/conf/magpietts/magpietts_inference_en.yaml
+++ b/examples/tts/conf/magpietts/magpietts_inference_en.yaml
@@ -32,7 +32,7 @@ model:
   speaker_emb_dim: 192
   max_decoder_steps: 500
   num_audio_codebooks: 8
-  num_audio_tokens_per_codebook: 2048 # Keep atleast 2 extra for eos/bos ids
+  num_audio_tokens_per_codebook: 2024 # 2016 from codec + 8 reserved tokens (for things like EOS/BOS etc.)
   codec_model_downsample_factor: 1024
   load_cached_codes_if_available: true
   prior_scaling_factor: null

--- a/examples/tts/conf/magpietts/magpietts_inference_multilingual_v1.yaml
+++ b/examples/tts/conf/magpietts/magpietts_inference_multilingual_v1.yaml
@@ -32,7 +32,7 @@ model:
   speaker_emb_dim: 192
   max_decoder_steps: 500
   num_audio_codebooks: 8
-  num_audio_tokens_per_codebook: 2048 # Keep atleast 2 extra for eos/bos ids
+  num_audio_tokens_per_codebook: 2024 # 2016 from codec + 8 reserved tokens (for things like EOS/BOS etc.)
   codec_model_downsample_factor: 1024
   load_cached_codes_if_available: true
   prior_scaling_factor: null

--- a/examples/tts/conf/magpietts/magpietts_lhotse_dc_en.yaml
+++ b/examples/tts/conf/magpietts/magpietts_lhotse_dc_en.yaml
@@ -10,7 +10,7 @@ model:
   context_duration_min: 3.0
   context_duration_max: 5.0
   num_audio_codebooks: 8
-  num_audio_tokens_per_codebook: 2_018 # Keep atleast 2 extra for eos/bos ids
+  num_audio_tokens_per_codebook: 2024 # 2016 from codec + 8 reserved tokens (for things like EOS/BOS etc.)
   codec_model_downsample_factor: 1_024
   codec_model_name: "21fpsCausalDecoder"
   load_cached_codes_if_available: true

--- a/examples/tts/conf/magpietts/magpietts_multilingual_v1.yaml
+++ b/examples/tts/conf/magpietts/magpietts_multilingual_v1.yaml
@@ -24,7 +24,7 @@ model:
   context_duration_max: 8.0
   speaker_emb_dim: 192 # Only used for single_encoder_sv_tts, ignored otherwise
   num_audio_codebooks: 8
-  num_audio_tokens_per_codebook: 2048 # Keep atleast 2 extra for eos/bos ids
+  num_audio_tokens_per_codebook: 2024 # 2016 from codec + 8 reserved tokens (for things like EOS/BOS etc.)
   codec_model_downsample_factor: 1024
   load_cached_codes_if_available: true
   prior_scaling_factor: 0.5


### PR DESCRIPTION
Make sure to reserve enough tokens for special uses like EOS/BOS.

Also, standardize all YAMLs to 2024 tokens.

WARNING: old models will be incompatible with the updated inference YAMLs and will need to override the num_audio_tokens_per_codebook to the value they were trained with.