### PR TITLE
DRAFT: refactor handling of num_codebooks and num_audio_codes in Magpie

### DIFF
--- a/examples/tts/conf/magpietts/magpietts_dc_en.yaml
+++ b/examples/tts/conf/magpietts/magpietts_dc_en.yaml
@@ -21,7 +21,7 @@ model:
   context_duration_min: 3.0
   context_duration_max: 5.0
   num_audio_codebooks: 8
-  num_audio_tokens_per_codebook: 2018 # 2016 from codec + Keep at least 2 extra for eos/bos ids
+  num_audio_tokens_per_codebook: 2024 # 2016 from codec + 8 reserved tokens (for things like EOS/BOS etc.)
   codec_model_downsample_factor: 1024
   load_cached_codes_if_available: true
   prior_scaling_factor: 0.5

--- a/examples/tts/conf/magpietts/magpietts_dc_en.yaml
+++ b/examples/tts/conf/magpietts/magpietts_dc_en.yaml
@@ -20,8 +20,7 @@ model:
   use_text_conditioning_encoder: false # If true, distilbert will be used to encode context_text if provided.
   context_duration_min: 3.0
   context_duration_max: 5.0
-  num_audio_codebooks: 8
-  num_audio_tokens_per_codebook: 2024 # 2016 from codec + 8 reserved tokens (for things like EOS/BOS etc.)
+  num_reserved_audio_tokens: 8
   codec_model_downsample_factor: 1024
   load_cached_codes_if_available: true
   prior_scaling_factor: 0.5

--- a/examples/tts/conf/magpietts/magpietts_en.yaml
+++ b/examples/tts/conf/magpietts/magpietts_en.yaml
@@ -23,7 +23,7 @@ model:
   context_duration_min: 3.0
   context_duration_max: 5.0
   num_audio_codebooks: 8
-  num_audio_tokens_per_codebook: 2018 # 2016 from codec + Keep at least 2 extra for eos/bos ids
+  num_audio_tokens_per_codebook: 2024 # 2016 from codec + 8 reserved tokens (for things like EOS/BOS etc.)
   codec_model_downsample_factor: 1024
   load_cached_codes_if_available: true
   prior_scaling_factor: 0.5

--- a/examples/tts/conf/magpietts/magpietts_en.yaml
+++ b/examples/tts/conf/magpietts/magpietts_en.yaml
@@ -22,8 +22,7 @@ model:
   context_decoder_layers: [8,9] # ONLY used in multi_encoder_context_tts
   context_duration_min: 3.0
   context_duration_max: 5.0
-  num_audio_codebooks: 8
-  num_audio_tokens_per_codebook: 2024 # 2016 from codec + 8 reserved tokens (for things like EOS/BOS etc.)
+  num_reserved_audio_tokens: 8
   codec_model_downsample_factor: 1024
   load_cached_codes_if_available: true
   prior_scaling_factor: 0.5

--- a/examples/tts/conf/magpietts/magpietts_inference_en.yaml
+++ b/examples/tts/conf/magpietts/magpietts_inference_en.yaml
@@ -32,7 +32,7 @@ model:
   speaker_emb_dim: 192
   max_decoder_steps: 500
   num_audio_codebooks: 8
-  num_audio_tokens_per_codebook: 2048 # Keep atleast 2 extra for eos/bos ids
+  num_audio_tokens_per_codebook: 2024 # 2016 from codec + 8 reserved tokens (for things like EOS/BOS etc.)
   codec_model_downsample_factor: 1024
   load_cached_codes_if_available: true
   prior_scaling_factor: null

--- a/examples/tts/conf/magpietts/magpietts_inference_en.yaml
+++ b/examples/tts/conf/magpietts/magpietts_inference_en.yaml
@@ -31,8 +31,7 @@ model:
   context_duration_max: 8.0
   speaker_emb_dim: 192
   max_decoder_steps: 500
-  num_audio_codebooks: 8
-  num_audio_tokens_per_codebook: 2024 # 2016 from codec + 8 reserved tokens (for things like EOS/BOS etc.)
+  num_reserved_audio_tokens: 8
   codec_model_downsample_factor: 1024
   load_cached_codes_if_available: true
   prior_scaling_factor: null

--- a/examples/tts/conf/magpietts/magpietts_inference_multilingual_v1.yaml
+++ b/examples/tts/conf/magpietts/magpietts_inference_multilingual_v1.yaml
@@ -32,7 +32,7 @@ model:
   speaker_emb_dim: 192
   max_decoder_steps: 500
   num_audio_codebooks: 8
-  num_audio_tokens_per_codebook: 2048 # Keep atleast 2 extra for eos/bos ids
+  num_audio_tokens_per_codebook: 2024 # 2016 from codec + 8 reserved tokens (for things like EOS/BOS etc.)
   codec_model_downsample_factor: 1024
   load_cached_codes_if_available: true
   prior_scaling_factor: null

--- a/examples/tts/conf/magpietts/magpietts_inference_multilingual_v1.yaml
+++ b/examples/tts/conf/magpietts/magpietts_inference_multilingual_v1.yaml
@@ -31,8 +31,7 @@ model:
   context_duration_max: 8.0
   speaker_emb_dim: 192
   max_decoder_steps: 500
-  num_audio_codebooks: 8
-  num_audio_tokens_per_codebook: 2024 # 2016 from codec + 8 reserved tokens (for things like EOS/BOS etc.)
+  num_reserved_audio_tokens: 8
   codec_model_downsample_factor: 1024
   load_cached_codes_if_available: true
   prior_scaling_factor: null

--- a/examples/tts/conf/magpietts/magpietts_lhotse_dc_en.yaml
+++ b/examples/tts/conf/magpietts/magpietts_lhotse_dc_en.yaml
@@ -10,7 +10,7 @@ model:
   context_duration_min: 3.0
   context_duration_max: 5.0
   num_audio_codebooks: 8
-  num_audio_tokens_per_codebook: 2_018 # Keep atleast 2 extra for eos/bos ids
+  num_audio_tokens_per_codebook: 2024 # 2016 from codec + 8 reserved tokens (for things like EOS/BOS etc.)
   codec_model_downsample_factor: 1_024
   codec_model_name: "21fpsCausalDecoder"
   load_cached_codes_if_available: true

--- a/examples/tts/conf/magpietts/magpietts_lhotse_dc_en.yaml
+++ b/examples/tts/conf/magpietts/magpietts_lhotse_dc_en.yaml
@@ -9,8 +9,7 @@ model:
   use_text_conditioning_encoder: false # If true, distilbert will be used to encode context_text if provided.
   context_duration_min: 3.0
   context_duration_max: 5.0
-  num_audio_codebooks: 8
-  num_audio_tokens_per_codebook: 2024 # 2016 from codec + 8 reserved tokens (for things like EOS/BOS etc.)
+  num_reserved_audio_tokens: 8
   codec_model_downsample_factor: 1_024
   codec_model_name: "21fpsCausalDecoder"
   load_cached_codes_if_available: true

--- a/examples/tts/conf/magpietts/magpietts_multilingual_v1.yaml
+++ b/examples/tts/conf/magpietts/magpietts_multilingual_v1.yaml
@@ -24,7 +24,7 @@ model:
   context_duration_max: 8.0
   speaker_emb_dim: 192 # Only used for single_encoder_sv_tts, ignored otherwise
   num_audio_codebooks: 8
-  num_audio_tokens_per_codebook: 2048 # Keep atleast 2 extra for eos/bos ids
+  num_audio_tokens_per_codebook: 2024 # 2016 from codec + 8 reserved tokens (for things like EOS/BOS etc.)
   codec_model_downsample_factor: 1024
   load_cached_codes_if_available: true
   prior_scaling_factor: 0.5

--- a/examples/tts/conf/magpietts/magpietts_multilingual_v1.yaml
+++ b/examples/tts/conf/magpietts/magpietts_multilingual_v1.yaml
@@ -23,8 +23,7 @@ model:
   context_duration_min: 3.0
   context_duration_max: 8.0
   speaker_emb_dim: 192 # Only used for single_encoder_sv_tts, ignored otherwise
-  num_audio_codebooks: 8
-  num_audio_tokens_per_codebook: 2024 # 2016 from codec + 8 reserved tokens (for things like EOS/BOS etc.)
+  num_reserved_audio_tokens: 8
   codec_model_downsample_factor: 1024
   load_cached_codes_if_available: true
   prior_scaling_factor: 0.5

--- a/nemo/collections/tts/models/magpietts.py
+++ b/nemo/collections/tts/models/magpietts.py
@@ -17,6 +17,7 @@ import random
 import string
 import time
 from typing import List
+from enum import Enum
 
 import librosa
 import numpy as np
@@ -97,6 +98,34 @@ class MagpieTTSModel(ModelPT):
         if trainer is not None:
             self.world_size = trainer.num_nodes * trainer.num_devices
 
+        # Reserve special tokens (appended at the end of the codebook after the codec tokens)
+        # (the actual index is this value plus the number of codec tokens - do not use the Enum directy)
+        class SpecialAudioToken(Enum):
+            AUDIO_BOS = 0
+            AUDIO_EOS = 1
+            AUDIO_CONTEXT_BOS = 2
+            AUDIO_CONTEXT_EOS = 3
+            MASK_TOKEN = 4
+            NUM_SPECIAL_TOKENS = 5 # update this if you special tokens
+
+        # load codec
+        codec_model = AudioCodecModel.restore_from(cfg.get('codecmodel_path'), strict=False)
+        # del codec discriminator to free memory
+        del codec_model.discriminator
+        self._codec_model = codec_model
+        self._codec_model.freeze()  #Lightning does requires_grad = False and self.eval()
+        
+        # Set up codebook configuration
+        # TODO @rfejgin: replace these to calls to an API at the codec (not quantizer) level once those are added
+        self.num_audio_codebooks = self._codec_model.vector_quantizer.num_groups
+        num_reserved_audio_tokens = cfg.get('num_reserved_audio_tokens', 8)
+        assert num_reserved_audio_tokens >= SpecialAudioToken.NUM_SPECIAL_TOKENS.value, "Are are not enough reserved entries for all special tokens"
+        self.num_audio_tokens_per_codebook = self._codec_model.vector_quantizer.codebook_size_per_group + num_reserved_audio_tokens
+        self.audio_bos_id = self.num_audio_tokens_per_codebook + SpecialAudioToken.AUDIO_BOS.value
+        self.audio_eos_id = self.num_audio_tokens_per_codebook + SpecialAudioToken.AUDIO_EOS.value
+        self.context_audio_bos_id = self.num_audio_tokens_per_codebook + SpecialAudioToken.AUDIO_CONTEXT_BOS.value
+        self.context_audio_eos_id = self.num_audio_tokens_per_codebook + SpecialAudioToken.AUDIO_CONTEXT_EOS.value
+
         # Setup tokenizer
         if hasattr(cfg, 'text_tokenizer'):
             # For backward compatibility for English-only models
@@ -119,18 +148,7 @@ class MagpieTTSModel(ModelPT):
         self.bos_id = num_tokens - 2
         self.eos_id = num_tokens - 1
 
-        self.audio_bos_id = cfg.num_audio_tokens_per_codebook - 2
-        self.audio_eos_id = cfg.num_audio_tokens_per_codebook - 1
-        self.context_audio_bos_id = cfg.num_audio_tokens_per_codebook - 2  # For backward compatibility
-        self.context_audio_eos_id = cfg.num_audio_tokens_per_codebook - 1  # For backward compatibility
-
         self.model_type = cfg.get('model_type', 'single_encoder_sv_tts')
-
-        if self.model_type == 'decoder_context_tts':
-            self.context_audio_bos_id = (
-                cfg.num_audio_tokens_per_codebook - 4
-            )  # Changing these to make them different from target audio bos and eos
-            self.context_audio_eos_id = cfg.num_audio_tokens_per_codebook - 3
 
         self.pad_context_text_to_max_duration = self.model_type == 'decoder_context_tts'
         self.use_kv_cache_for_inference = cfg.get('use_kv_cache_for_inference', False)
@@ -141,8 +159,8 @@ class MagpieTTSModel(ModelPT):
             self.context_text_embedding = nn.Embedding(self.text_conditioning_tokenizer.vocab_size, cfg.embedding_dim)
 
         audio_embeddings = []
-        for _ in range(cfg.num_audio_codebooks):
-            audio_embeddings.append(nn.Embedding(cfg.num_audio_tokens_per_codebook, cfg.embedding_dim))
+        for _ in range(self.num_audio_codebooks):
+            audio_embeddings.append(nn.Embedding(self.num_audio_tokens_per_codebook, cfg.embedding_dim))
         self.audio_embeddings = nn.ModuleList(audio_embeddings)
 
         if self.model_type != 'decoder_pretrain_synthesizer':
@@ -151,7 +169,7 @@ class MagpieTTSModel(ModelPT):
             self.encoder = transformer_2501.Transformer(**dict(cfg.encoder))
 
         self.decoder = transformer_2501.Transformer(**dict(cfg.decoder))
-        self.final_proj = nn.Linear(cfg.decoder.d_model, cfg.num_audio_codebooks * cfg.num_audio_tokens_per_codebook)
+        self.final_proj = nn.Linear(cfg.decoder.d_model, self.num_audio_codebooks * self.num_audio_tokens_per_codebook)
         if cfg.get('use_local_transformer', False):
             local_transformer_hidden_dim = cfg.get('local_transformer_hidden_dim', 256)
             if local_transformer_hidden_dim != cfg.decoder.d_model:
@@ -165,13 +183,13 @@ class MagpieTTSModel(ModelPT):
                 sa_n_heads=self.cfg.get('local_transformer_n_heads', 1),
                 kernel_size=1,
                 is_causal=True,
-                max_length_causal_mask=cfg.num_audio_codebooks+2,
+                max_length_causal_mask=self.num_audio_codebooks+2,
                 use_learnable_pos_emb=True,
             )
             local_transformer_out_projections = []
-            for _ in range(cfg.num_audio_codebooks):
+            for _ in range(self.num_audio_codebooks):
                 # Have a separate projection layer for each codebook, to distinguish between them
-                local_transformer_out_projections.append(nn.Linear(local_transformer_hidden_dim, cfg.num_audio_tokens_per_codebook))
+                local_transformer_out_projections.append(nn.Linear(local_transformer_hidden_dim, self.num_audio_tokens_per_codebook))
             self.local_transformer_out_projections = nn.ModuleList(local_transformer_out_projections)
 
         if cfg.get('use_alignment_encoder', False):
@@ -181,12 +199,6 @@ class MagpieTTSModel(ModelPT):
                 dist_type="cosine",
                 temperature=15.0,
             )
-
-        codec_model = AudioCodecModel.restore_from(cfg.get('codecmodel_path'), strict=False)
-        # del codec discriminator to free memory
-        del codec_model.discriminator
-        self._codec_model = codec_model
-        self._codec_model.freeze()  #Lightning does requires_grad = False and self.eval()
 
         if self.model_type == 'single_encoder_sv_tts':
             self._speaker_verification_model = nemo_asr.models.EncDecSpeakerLabelModel.from_pretrained(
@@ -351,8 +363,8 @@ class MagpieTTSModel(ModelPT):
         loss_mask = get_mask_from_lengths(audio_codes_lens)
         total_codebook_loss = None
         for codebook in range(audio_codes.size(1)):
-            si = codebook * self.cfg.num_audio_tokens_per_codebook
-            ei = si + self.cfg.num_audio_tokens_per_codebook
+            si = codebook * self.num_audio_tokens_per_codebook
+            ei = si + self.num_audio_tokens_per_codebook
             codebook_logits = logits[:, :, si:ei]  # (B, T', num_tokens_per_codebook)
             codebook_targets = audio_codes[:, codebook]  # (B, T')
             codebook_loss = self.cross_entropy_loss(
@@ -385,9 +397,9 @@ class MagpieTTSModel(ModelPT):
         # all_code_logits: (B, T', num_codebooks * num_tokens_per_codebook)
         # audio_codes_lens: (B,)
         all_preds = []
-        for idx in range(self.cfg.num_audio_codebooks):
-            si = idx * self.cfg.num_audio_tokens_per_codebook
-            ei = si + self.cfg.num_audio_tokens_per_codebook
+        for idx in range(self.num_audio_codebooks):
+            si = idx * self.num_audio_tokens_per_codebook
+            ei = si + self.num_audio_tokens_per_codebook
             codebook_logits = all_code_logits[:, :, si:ei]
             codebook_probs = torch.softmax(codebook_logits, dim=-1)  # (B, T', num_tokens_per_codebook)
             # argmax to get the tokens
@@ -406,7 +418,7 @@ class MagpieTTSModel(ModelPT):
         dec_output = dec_output.unsqueeze(1) # (B, 1, E)
         local_transformer_input = self.local_transformer_in_projection(dec_output) # (B, 1, 128)
         all_preds = []
-        for codebook_num in range(self.cfg.num_audio_codebooks):
+        for codebook_num in range(self.num_audio_codebooks):
             _mask = torch.ones( local_transformer_input.size(0), local_transformer_input.size(1), device=local_transformer_input.device)
             local_transformer_output = self.local_transformer(local_transformer_input, _mask)['output'] # (B, T, 128)
             codebook_logits = self.local_transformer_out_projections[codebook_num](local_transformer_output[:, -1, :]) # (B, num_audio_tokens_per_codebook)
@@ -446,9 +458,9 @@ class MagpieTTSModel(ModelPT):
     def sample_codes_from_logits(self, all_code_logits_t, temperature=0.7, topk=80, unfinished_items={}, finished_items={}):
         # all_code_logits_t: (B, num_codebooks * num_tokens_per_codebook), logits at a given timestep
         all_preds = []
-        for idx in range(self.cfg.num_audio_codebooks):
-            si = idx * self.cfg.num_audio_tokens_per_codebook
-            ei = si + self.cfg.num_audio_tokens_per_codebook
+        for idx in range(self.num_audio_codebooks):
+            si = idx * self.num_audio_tokens_per_codebook
+            ei = si + self.num_audio_tokens_per_codebook
             codebook_logits = all_code_logits_t[:, si:ei]  # (B, num_tokens_per_codebook)
             for item_idx in unfinished_items:
                 codebook_logits[item_idx, self.audio_eos_id] = float('-inf')
@@ -874,7 +886,7 @@ class MagpieTTSModel(ModelPT):
                 and torch.rand(1).item() < 0.5
             ):
                 # For some batches (half of them), replace decoder_input_dropout_prob of the timesteps with random tokens
-                max_codebook_val = self.cfg.get('dec_random_input_max', self.cfg.num_audio_tokens_per_codebook)
+                max_codebook_val = self.cfg.get('dec_random_input_max', self.num_audio_tokens_per_codebook)
                 # @pneekhara: Keeping dec_random_input_max configurable since num_audio_tokens_per_codebook usually has padding tokens
                 # which can cause errors when doing codes_to_audio for audio_codes_input. We are not currently calling codes_to_audio on
                 # audio_codes_input so should not matter if we don't supply dec_random_input_max.
@@ -1216,7 +1228,7 @@ class MagpieTTSModel(ModelPT):
             context_tensors = self.prepare_context_tensors(batch)
             text = context_tensors['text']
             audio_codes_bos = torch.full(
-                (text.size(0), self.cfg.num_audio_codebooks, 1), self.audio_bos_id, device=text.device
+                (text.size(0), self.num_audio_codebooks, 1), self.audio_bos_id, device=text.device
             ).long()
             audio_codes_lens = torch.full((text.size(0),), 1, device=text.device).long()
             audio_codes_input = audio_codes_bos
@@ -1489,7 +1501,7 @@ class MagpieTTSModel(ModelPT):
             audio_eos_id=self.audio_eos_id,
             context_audio_bos_id=self.context_audio_bos_id,
             context_audio_eos_id=self.context_audio_eos_id,
-            num_audio_codebooks=self.cfg.num_audio_codebooks,
+            num_audio_codebooks=self.num_audio_codebooks,
             codec_model_downsample_factor=self.cfg.codec_model_downsample_factor,
             prior_scaling_factor=self.cfg.prior_scaling_factor,
             load_cached_codes_if_available=self.cfg.load_cached_codes_if_available,
@@ -1517,7 +1529,7 @@ class MagpieTTSModel(ModelPT):
             audio_eos_id=self.audio_eos_id,
             context_audio_bos_id=self.context_audio_bos_id,
             context_audio_eos_id=self.context_audio_eos_id,
-            num_audio_codebooks=self.cfg.num_audio_codebooks,
+            num_audio_codebooks=self.num_audio_codebooks,
             prior_scaling_factor=self.cfg.prior_scaling_factor,
             load_cached_codes_if_available=self.cfg.load_cached_codes_if_available,
             dataset_type=mode,  # train or test used for setting phone prob to 1.0 in test dataset (worker_init_fn)


### PR DESCRIPTION
Note: this is an untested draft to demonstrate the idea - please do **not** merge.

The idea is that rather than defining the number of codebooks, number of codes per codebook and downsampling factor in the Magpie configuration files, we read them from the codec since these parameters must match for the system to work.

That would mean that Magpie would only need to define the number of "special tokens" (like EOS, BOS) to be added after the audio codec tokens positions in the Magpie embedding table. This makes sense since Magpie is the only one that needs to be aware of those.

Ryan L. is adding APIs to the codec so that we can read the relevant parameters; for now we have temporarily implemented this by reaching into the codec (wouldn't work for all codec flavors).
