### PR TITLE
Add num_codebooks and codebook_size to codec interface

### DIFF
--- a/nemo/collections/tts/models/audio_codec.py
+++ b/nemo/collections/tts/models/audio_codec.py
@@ -195,6 +195,20 @@ class AudioCodecModel(ModelPT):
     def dtype(self):
         return next(self.parameters()).dtype
 
+    @property
+    def num_codebooks(self):
+        if self.vector_quantizer is None:
+            raise ValueError("This AudioCodecModel does not have a vector quantizer.")
+
+        return self.vector_quantizer.num_codebooks
+
+    @property
+    def codebook_size(self):
+        if self.vector_quantizer is None:
+            raise ValueError("This AudioCodecModel does not have a vector quantizer.")
+
+        return self.vector_quantizer.codebook_size
+
     def state_dict(self, destination=None, prefix='', keep_vars=False):
         if hasattr(self, '_no_state_dict') and self._no_state_dict:
             return {}

--- a/nemo/collections/tts/modules/audio_codec_modules.py
+++ b/nemo/collections/tts/modules/audio_codec_modules.py
@@ -1118,6 +1118,16 @@ class Discriminator(NeuralModule):
 
 class VectorQuantizerBase(NeuralModule, ABC):
     @property
+    @abstractmethod
+    def num_codebooks(self) -> int:
+        pass
+
+    @property
+    @abstractmethod
+    def codebook_size(self) -> int:
+        pass
+
+    @property
     def input_types(self):
         return {
             "inputs": NeuralType(('B', 'D', 'T'), EncodedRepresentation()),
@@ -1195,6 +1205,11 @@ class FiniteScalarQuantizer(VectorQuantizerBase):
         logging.debug('\tnum_levels:    %s', self.num_levels)
         logging.debug('\tcodebook_size: %s', self.codebook_size)
         logging.debug('\teps:           %s', self.eps)
+
+    @property
+    def num_codebooks(self):
+        """Returns the number of codebooks."""
+        return 1
 
     @property
     def codebook_size(self):
@@ -1392,19 +1407,24 @@ class GroupFiniteScalarQuantizer(VectorQuantizerBase):
         logging.debug('\tcodebook_dim_per_group:  %d', self.codebook_dim_per_group)
 
     @property
-    def codebook_dim(self):
-        """Input vector dimension."""
-        return self.codebook_dim_per_group * self.num_groups
-
-    @property
-    def codebook_size_per_group(self):
-        """Returns the size of the implicit codebook for each group."""
-        return self.fsqs[0].codebook_size
+    def num_codebooks(self):
+        """Returns the number of codebooks."""
+        return self.num_groups
 
     @property
     def codebook_size(self):
-        """Returns the size of the implicit codebook."""
-        return self.codebook_size_per_group**self.num_groups
+        """Returns the size of the codebook for each group."""
+        return self.fsqs[0].codebook_size
+
+    #@property
+    #def codebook_size(self):
+    #    """Returns the size of the implicit codebook."""
+    #    return self.codebook_size_per_group**self.num_groups
+
+    @property
+    def codebook_dim(self):
+        """Input vector dimension."""
+        return self.codebook_dim_per_group * self.num_groups
 
     @typecheck()
     def forward(self, inputs, input_len):

--- a/nemo/collections/tts/modules/encodec_modules.py
+++ b/nemo/collections/tts/modules/encodec_modules.py
@@ -739,6 +739,16 @@ class ResidualVectorQuantizer(VectorQuantizerBase):
             ]
         )
 
+    @property
+    def num_codebooks(self):
+        """Returns the number of codebooks."""
+        return len(self.codebooks)
+
+    @property
+    def codebook_size(self):
+        """Returns the size of the codebook for each group."""
+        return self.codebooks[0].codebook_size
+
     # Override output types, since this quantizer returns commit_loss
     @property
     def output_types(self):
@@ -837,7 +847,6 @@ class GroupResidualVectorQuantizer(VectorQuantizerBase):
     def __init__(self, num_codebooks: int, num_groups: int, codebook_dim: int, **kwargs):
         super().__init__()
 
-        self.num_codebooks = num_codebooks
         self.num_groups = num_groups
         self.codebook_dim = codebook_dim
 
@@ -857,6 +866,16 @@ class GroupResidualVectorQuantizer(VectorQuantizerBase):
         logging.debug('\tcodebook_dim:            %d', self.codebook_dim)
         logging.debug('\tnum_codebooks_per_group: %d', self.num_codebooks_per_group)
         logging.debug('\tcodebook_dim_per_group:  %d', self.codebook_dim_per_group)
+
+    @property
+    def num_codebooks(self):
+        """Returns the number of codebooks."""
+        return self.num_groups
+
+    @property
+    def codebook_size(self):
+        """Returns the size of the codebook for each group."""
+        return self.rvqs[0].codebook_size
 
     @property
     def num_codebooks_per_group(self):


### PR DESCRIPTION
Add parameters to AudioCodecModel interface so they can be accessed easily without having to look into fields in the underlying vector quantizer implementation