### PR TITLE
bug fix in _setup_test_dataloader when num workers=0

### DIFF
--- a/nemo/collections/tts/models/magpietts.py
+++ b/nemo/collections/tts/models/magpietts.py
@@ -1573,7 +1573,7 @@ class MagpieTTSModel(ModelPT):
                 # For num workers > 0 tokenizer will be assigned in worker_init_fn (since it is not picklable)
                 dataset.text_tokenizer, dataset.text_conditioning_tokenizer = setup_tokenizers(
                     all_tokenizers_config=self.cfg.text_tokenizers,
-                    use_text_conditioning_tokenizer=self.use_kv_cache_for_inference,
+                    use_text_conditioning_tokenizer=self.use_text_conditioning_encoder,
                     mode='test'
                 )
 


### PR DESCRIPTION
Bug fix in val dataloader when num workers=0. Context text tokenizer was not being initialized in the dataset.