### PR TITLE
Python 3.10 compatibility

### DIFF
--- a/examples/tts/conf/magpietts/magpietts_dc_en.yaml
+++ b/examples/tts/conf/magpietts/magpietts_dc_en.yaml
@@ -50,10 +50,10 @@ model:
   aligner_encoder_train_steps: 50000
 
   # Local transformer parameters for autoregressive codebook prediction within a frame
-  local_transformer_type: "none" # "none", "autoregressive", "maskgit"
+  local_transformer_type: "autoregressive" # "none", "autoregressive", "maskgit"
   # Below args are only relevant if use_local_transformer is true
   local_transformer_loss_scale: 1.0
-  local_transformer_n_layers: 1
+  local_transformer_n_layers: 3
   local_transformer_n_heads: 1
   local_transformer_hidden_dim: 256
 
@@ -155,6 +155,7 @@ trainer:
   check_val_every_n_epoch: 1
   num_sanity_val_steps: 0
   benchmark: false
+  gradient_clip_val: 2.5
 
 exp_manager:
   exp_dir: null

--- a/examples/tts/conf/magpietts/magpietts_en.yaml
+++ b/examples/tts/conf/magpietts/magpietts_en.yaml
@@ -52,10 +52,10 @@ model:
   aligner_encoder_train_steps: 50000
 
   # Local transformer parameters for autoregressive codebook prediction within a frame
-  local_transformer_type: "none" # "none", "autoregressive", "maskgit"
+  local_transformer_type: "autoregressive" # "none", "autoregressive", "maskgit"
   # Below args are only relevant if use_local_transformer is true
   local_transformer_loss_scale: 1.0
-  local_transformer_n_layers: 1
+  local_transformer_n_layers: 3
   local_transformer_n_heads: 1
   local_transformer_hidden_dim: 256
 
@@ -171,6 +171,7 @@ trainer:
   check_val_every_n_epoch: 1
   num_sanity_val_steps: 0
   benchmark: false
+  gradient_clip_val: 2.5
 
 exp_manager:
   exp_dir: null

--- a/examples/tts/conf/magpietts/magpietts_inference_en.yaml
+++ b/examples/tts/conf/magpietts/magpietts_inference_en.yaml
@@ -60,10 +60,10 @@ model:
   aligner_encoder_train_steps: 50000
 
   # Local transformer parameters for autoregressive codebook prediction within a frame
-  local_transformer_type: "none" # "none", "autoregressive", "maskgit"
+  local_transformer_type: "autoregressive" # "none", "autoregressive", "maskgit"
   # Below args are only relevant if use_local_transformer is true
   local_transformer_loss_scale: 1.0
-  local_transformer_n_layers: 1
+  local_transformer_n_layers: 3
   local_transformer_n_heads: 1
   local_transformer_hidden_dim: 256
 
@@ -163,6 +163,7 @@ trainer:
   val_check_interval: 500
   # check_val_every_n_epoch: 10
   benchmark: false
+  gradient_clip_val: 2.5
 
 exp_manager:
   exp_dir: null

--- a/examples/tts/conf/magpietts/magpietts_inference_multilingual_v1.yaml
+++ b/examples/tts/conf/magpietts/magpietts_inference_multilingual_v1.yaml
@@ -60,10 +60,10 @@ model:
   aligner_encoder_train_steps: 50000
 
   # Local transformer parameters for autoregressive codebook prediction within a frame
-  local_transformer_type: "none" # "none", "autoregressive", "maskgit"
+  local_transformer_type: "autoregressive" # "none", "autoregressive", "maskgit"
   # Below args are only relevant if use_local_transformer is true
   local_transformer_loss_scale: 1.0
-  local_transformer_n_layers: 1
+  local_transformer_n_layers: 3
   local_transformer_n_heads: 1
   local_transformer_hidden_dim: 256
 
@@ -211,6 +211,7 @@ trainer:
   val_check_interval: 500
   # check_val_every_n_epoch: 10
   benchmark: false
+  gradient_clip_val: 2.5
 
 exp_manager:
   exp_dir: null

--- a/examples/tts/conf/magpietts/magpietts_lhotse_dc_en.yaml
+++ b/examples/tts/conf/magpietts/magpietts_lhotse_dc_en.yaml
@@ -38,10 +38,10 @@ model:
   aligner_encoder_train_steps: 50_000
 
   # Local transformer parameters for autoregressive codebook prediction within a frame
-  local_transformer_type: "none" # "none", "autoregressive", "maskgit"
+  local_transformer_type: "autoregressive" # "none", "autoregressive", "maskgit"
   # Below args are only relevant if use_local_transformer is true
   local_transformer_loss_scale: 1.0
-  local_transformer_n_layers: 1
+  local_transformer_n_layers: 3
   local_transformer_n_heads: 1
   local_transformer_hidden_dim: 256
 
@@ -165,6 +165,7 @@ trainer:
   num_sanity_val_steps: 0
   benchmark: false
   use_distributed_sampler: false  # required because Lhotse has its own handling
+  gradient_clip_val: 2.5
 
 
 exp_manager:

--- a/examples/tts/conf/magpietts/magpietts_multilingual_v1.yaml
+++ b/examples/tts/conf/magpietts/magpietts_multilingual_v1.yaml
@@ -53,10 +53,10 @@ model:
   aligner_encoder_train_steps: 50000
 
   # Local transformer parameters for autoregressive codebook prediction within a frame
-  local_transformer_type: "none" # "none", "autoregressive", "maskgit"
+  local_transformer_type: "autoregressive" # "none", "autoregressive", "maskgit"
   # Below args are only relevant if use_local_transformer is true
   local_transformer_loss_scale: 1.0
-  local_transformer_n_layers: 1
+  local_transformer_n_layers: 3
   local_transformer_n_heads: 1
   local_transformer_hidden_dim: 256
 
@@ -219,6 +219,7 @@ trainer:
   val_check_interval: 500
   # check_val_every_n_epoch: 10
   benchmark: false
+  gradient_clip_val: 2.5
 
 exp_manager:
   exp_dir: null

--- a/nemo/collections/tts/models/magpietts.py
+++ b/nemo/collections/tts/models/magpietts.py
@@ -264,8 +264,9 @@ class MagpieTTSModel(ModelPT):
                 # Ex: state_dict[encoder.position_embeddings.weight] -> new_state_dict[position_embeddings.weight]
                 new_state_dict = {}
                 for key in state_dict.keys():
-                    if key.startswith(name):
-                        new_state_dict[key[len(name)+1:]] = state_dict[key]  # +1 for '.'
+                    name_with_dot = f"{name}."
+                    if key.startswith(name_with_dot):
+                        new_state_dict[key[len(name_with_dot):]] = state_dict[key]
                 child.load_state_dict(new_state_dict)
 
     def audio_to_codes(self, audio, audio_len, audio_type='target'):

--- a/nemo/collections/tts/modules/magpietts_modules.py
+++ b/nemo/collections/tts/modules/magpietts_modules.py
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from enum import Enum, StrEnum, verify, CONTINUOUS, UNIQUE
+from enum import Enum
+from nemo.utils.enum import PrettyStrEnum
 import torch
 
 
-class LocalTransformerType(StrEnum):
+class LocalTransformerType(PrettyStrEnum):
     """
     Enum for the type of local transformer to use in the MagpieTTS model.
     These strings are the values allowed in the YAML config file.
@@ -27,7 +28,6 @@ class LocalTransformerType(StrEnum):
     MASKGIT = "maskgit"
 
 
-@verify(CONTINUOUS, UNIQUE)
 class SpecialAudioToken(Enum):
     """
     Enum for the special tokens to use in the MagpieTTS model.


### PR DESCRIPTION
Removes dependencies on Enum features only present in Python 3.11 and later.

- Remove dependency on StrEnum (requires Python >= 3.11) and replaced it with NeMo's PrettyStrEnum.
- Remove use of @verify decorator from Enum class which requires Python 3.11